### PR TITLE
Execute R code when loading a dataset

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ Suggests:
 Depends:
     R (>= 3.2.0)
 Imports:
+    datasets,
     purrr,
     jsonlite,
     Rcpp

--- a/data/rpwnd.R
+++ b/data/rpwnd.R
@@ -1,0 +1,5 @@
+if (interactive()) {
+  message("While loading this dataset, potentially untrusted R code was executed.")
+  message(paste0("Current time: ", Sys.time()))
+  assign("rpwnd", datasets::mtcars)
+}


### PR DESCRIPTION
I was looking at the source code of the `data` function. Turns out it executes R code. Potential scenario: hide code in a dataset, trick the user into executing `data("rpwnd")` and use this to run malicious code. 